### PR TITLE
Use new webcomponents-helper

### DIFF
--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>com.vaadin</groupId>
 			<artifactId>webcomponents-helper</artifactId>
-			<version>0.1-SNAPSHOT</version>
+			<version>0.2-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
https://github.com/vaadin/framework/pull/9368 changes the API used by the
webcomponents helper. This PR updates to use a new version of the helper that
will work with framework versions after API change has been submitted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/board/54)
<!-- Reviewable:end -->
