### PR TITLE
pin the version of the WebComponents polyfills to the one which works (fix #107)

### DIFF
--- a/precompiled/src/main/frontend/bower.json
+++ b/precompiled/src/main/frontend/bower.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "vaadin-addons": "./vaadin-addons/bower.json",
-    "webcomponentsjs": "^1.0.0"
+    "polymer": "2.0.1",
+    "webcomponentsjs": "1.0.1"
   }
 }
-


### PR DESCRIPTION
The latest version of the WebComponents polyfills has a bug which makes vaadin-board unusable in Firefox and IE11. Until the bug is fixed, the version of webcomponentsjs polyfills used to build the the precompiled vaadin board package has to be pinned (to avoid using the latest). The version of polymer is pinned as well but only because the latest version of polymer requires the latest version of webcomponentsjs.

 WebComponents polyfills issue: https://github.com/webcomponents/webcomponentsjs/issues/811

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/board/110)
<!-- Reviewable:end -->
