### PR TITLE
Update vaadin.version to non-release candidate (#121)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	</organization>
 	
 	<properties>
-		<vaadin.version>8.1.0.rc2</vaadin.version>
+		<vaadin.version>8.1.0</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 	</properties>
 


### PR DESCRIPTION
Release candidates don't exist in Maven Central any more

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/board/122)
<!-- Reviewable:end -->
