### PR TITLE
Fix broken examples on IE11

### DIFF
--- a/integration-tests/src/main/java/com/vaadin/addon/board/examples/ImageCollage.java
+++ b/integration-tests/src/main/java/com/vaadin/addon/board/examples/ImageCollage.java
@@ -95,10 +95,7 @@ public class ImageCollage extends VerticalLayout {
     private Component createImageBox(int n) {
         // IE11 has an issue for calculating flex-basis if element has margin, padding or border
         // Adding a wrapper fixes the issue
-        VerticalLayout container = new VerticalLayout();
-        container.setSpacing(false);
-        container.setMargin(false);
-        container.setStyleName("image-collage-container");
+        CssLayout container = new CssLayout();
 
         CssLayout innerContainer = new CssLayout();
         innerContainer.setStyleName("image-collage-item");

--- a/integration-tests/src/main/java/com/vaadin/addon/board/examples/ImageCollage.java
+++ b/integration-tests/src/main/java/com/vaadin/addon/board/examples/ImageCollage.java
@@ -97,16 +97,14 @@ public class ImageCollage extends VerticalLayout {
         // Adding a wrapper fixes the issue
         CssLayout container = new CssLayout();
 
-        CssLayout innerContainer = new CssLayout();
-        innerContainer.setStyleName("image-collage-item");
-
         n = (n - 1) % resources.length;
-        Image image = new Image("", resources[n]);
+
+        Image image = new Image();
+        image.setSource(resources[n]);
         image.setSizeFull();
+        image.setStyleName("image-collage-item");
 
-        innerContainer.addComponents(image);
-
-        container.addComponent(innerContainer);
+        container.addComponents(image);
 
         return container;
     }

--- a/integration-tests/src/main/java/com/vaadin/addon/board/examples/ImageCollage.java
+++ b/integration-tests/src/main/java/com/vaadin/addon/board/examples/ImageCollage.java
@@ -93,14 +93,23 @@ public class ImageCollage extends VerticalLayout {
         }
     }
     private Component createImageBox(int n) {
-        CssLayout container = new CssLayout();
-        container.setStyleName("image-collage-item");
+        // IE11 has an issue for calculating flex-basis if element has margin, padding or border
+        // Adding a wrapper fixes the issue
+        VerticalLayout container = new VerticalLayout();
+        container.setSpacing(false);
+        container.setMargin(false);
+        container.setStyleName("image-collage-container");
+
+        CssLayout innerContainer = new CssLayout();
+        innerContainer.setStyleName("image-collage-item");
 
         n = (n - 1) % resources.length;
         Image image = new Image("", resources[n]);
         image.setSizeFull();
 
-        container.addComponents(image);
+        innerContainer.addComponents(image);
+
+        container.addComponent(innerContainer);
 
         return container;
     }

--- a/integration-tests/src/main/java/com/vaadin/addon/board/examples/RowTypes.java
+++ b/integration-tests/src/main/java/com/vaadin/addon/board/examples/RowTypes.java
@@ -103,7 +103,13 @@ public class RowTypes extends VerticalLayout {
     }
 
     public Component createBox(String number, String size) {
-        CssLayout boxContainer = new CssLayout();
+        // IE11 has an issue for calculating flex-basis if element has margin, padding or border
+        // Adding a wrapper fixes the issue
+        VerticalLayout boxContainer = new VerticalLayout();
+        boxContainer.setMargin(false);
+        boxContainer.setSpacing(false);
+
+        CssLayout innerContainer = new CssLayout();
 
         Label numberLbl = new Label(number);
         numberLbl.addStyleName("box__number");
@@ -111,8 +117,10 @@ public class RowTypes extends VerticalLayout {
         Label sizeLbl = new Label(size);
         sizeLbl.addStyleName("box__size");
 
-        boxContainer.addComponents(numberLbl, sizeLbl);
-        boxContainer.addStyleName("box");
+        innerContainer.addComponents(numberLbl, sizeLbl);
+        innerContainer.addStyleName("box");
+
+        boxContainer.addComponent(innerContainer);
 
         return boxContainer;
     }

--- a/integration-tests/src/main/java/com/vaadin/addon/board/examples/RowTypes.java
+++ b/integration-tests/src/main/java/com/vaadin/addon/board/examples/RowTypes.java
@@ -105,9 +105,7 @@ public class RowTypes extends VerticalLayout {
     public Component createBox(String number, String size) {
         // IE11 has an issue for calculating flex-basis if element has margin, padding or border
         // Adding a wrapper fixes the issue
-        VerticalLayout boxContainer = new VerticalLayout();
-        boxContainer.setMargin(false);
-        boxContainer.setSpacing(false);
+        CssLayout boxContainer = new CssLayout();
 
         CssLayout innerContainer = new CssLayout();
 

--- a/integration-tests/src/main/webapp/VAADIN/themes/mytheme/styles.scss
+++ b/integration-tests/src/main/webapp/VAADIN/themes/mytheme/styles.scss
@@ -39,15 +39,6 @@
     padding: 10px;
     background: #dedede;
     border: 5px solid #FFF;
-
-    .v-caption {
-      display: none;
-    }
-
-    img {
-      min-width: 100%;
-      min-height: 100%;
-      object-fit: cover;
-    }
+    object-fit: cover;
   }
 }

--- a/integration-tests/src/main/webapp/VAADIN/themes/mytheme/styles.scss
+++ b/integration-tests/src/main/webapp/VAADIN/themes/mytheme/styles.scss
@@ -31,11 +31,6 @@
     }
   }
 
-  .image-collage-container > * {
-    height: 100%;
-    width: 100%;
-  }
-
   .image-collage-item {
     height: 100%;
     width: 100%;

--- a/integration-tests/src/main/webapp/VAADIN/themes/mytheme/styles.scss
+++ b/integration-tests/src/main/webapp/VAADIN/themes/mytheme/styles.scss
@@ -31,7 +31,14 @@
     }
   }
 
+  .image-collage-container > * {
+    height: 100%;
+    width: 100%;
+  }
+
   .image-collage-item {
+    height: 100%;
+    width: 100%;
     min-height: 300px;
     overflow: hidden;
     padding: 10px;


### PR DESCRIPTION
IE11 doesn't calculate `flex-basi`s well if element has margin,
padding or border, even if it has `box-sizing: border-box`.
In order to prevent it to break, one can add a wrapper, so the
`flex-basis` will work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/board/127)
<!-- Reviewable:end -->
