### PR TITLE
Removed license key installation instructions

### DIFF
--- a/documentation/webcomponents-api/getting-started.asciidoc
+++ b/documentation/webcomponents-api/getting-started.asciidoc
@@ -76,17 +76,6 @@ Next we'll modify your app to include a Vaadin Board. Open your app element in `
 <link rel="import" href="../../bower_components/vaadin-board/vaadin-board.html">
 ----
 
-[[board.project.setup.installing.license]]
-== Install your license key
-
-You need to install a license key in order to develop your application with the Vaadin Board web component.
-
-You can purchase a subscription or obtain a free trial key from the https://vaadin.com/pro/licenses[Vaadin Licenses page].
-You need to register in the Vaadin website to obtain the key.
-
-When you first time open your web page with Vaadin Board, you will see a pop-up that asks you to enter the license key.
-If the license is valid, it will be saved to the local storage of the browser and you will not see the pop-up again.
-
 [[board.project.setup.configuration]]
 == Add the Vaadin Board component to your web page
 


### PR DESCRIPTION
No need to tell how to install license. The UI will guide you and there are no licenses keys anymore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/board/131)
<!-- Reviewable:end -->
