### PR TITLE
Pin polymer-cli to 1.6.0 and update node/yarn

### DIFF
--- a/precompiled/pom.xml
+++ b/precompiled/pom.xml
@@ -77,8 +77,8 @@
 				<artifactId>frontend-maven-plugin</artifactId>
 				<version>1.4</version>
 				<configuration>
-					<nodeVersion>v6.9.1</nodeVersion>
-					<yarnVersion>v0.22.0</yarnVersion>
+					<nodeVersion>v8.11.2</nodeVersion>
+					<yarnVersion>v0.27.5</yarnVersion>
 					<workingDirectory>${frontend.working.directory}</workingDirectory>
 				</configuration>
 				<executions>

--- a/precompiled/src/main/frontend/package.json
+++ b/precompiled/src/main/frontend/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "bower": "^1.8.0",
     "gulp": "^3.9.1",
-    "polymer-cli": "next",
+    "polymer-cli": "^1.6.0",
     "mkdirp": "^0.5.1"
   },
   "scripts": {

--- a/precompiled/src/main/frontend/package.json
+++ b/precompiled/src/main/frontend/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "bower": "^1.8.0",
     "gulp": "^3.9.1",
-    "polymer-cli": "^1.6.0",
+    "polymer-cli": "1.6.0",
     "mkdirp": "^0.5.1"
   },
   "scripts": {


### PR DESCRIPTION
`polymer-cli@next` is resolving to `1.7.x`, which in incompatible with node < 8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/board/135)
<!-- Reviewable:end -->
